### PR TITLE
refactor(build): Add Gradle task to download JSON schema for different platforms

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,13 +48,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '24'
+          distribution: 'temurin'
+          architecture: x64
+      - uses: gradle/actions/setup-gradle@v3
 
-      - name: Install the JSON Schema CLI
-        uses: sourcemeta/jsonschema@v12.0.0
-
-      - run: |
-          mkdir -p build/json-schema
-          jsonschema bundle yaml/src/main/json-schema/vulnlog.schema.json --resolve yaml/src/main/json-schema --extension schema.json -w > build/json-schema/vulnlog-schema.json
+      - run: ./gradlew bundleJsonSchema
 
       - name: Upload schema
         uses: actions/upload-artifact@v4
@@ -73,7 +74,6 @@ jobs:
           distribution: 'temurin'
           architecture: x64
       - uses: gradle/actions/setup-gradle@v3
-      - uses: sourcemeta/jsonschema@v12.0.0
       - name: Clean build and zip distribution
         run: |
           VERSION="${{ github.ref_name }}"
@@ -94,7 +94,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: gradle/actions/setup-gradle@v3
-      - uses: sourcemeta/jsonschema@v12.0.0
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '24'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,4 @@ jobs:
           distribution: 'temurin'
           architecture: x64
       - uses: gradle/actions/setup-gradle@v3
-      - uses: sourcemeta/jsonschema@v12.0.0
       - run: ./gradlew check

--- a/yaml/README.md
+++ b/yaml/README.md
@@ -1,8 +1,5 @@
 # YAML and JSON Schema PoC
 
-This PoC requires [jsonschema](https://github.com/sourcemeta/jsonschema) installed on the system to
-run all the Gradle tasks.
-
 - [vulnlog.json](vulnlog.json) contains the whole Vulnlog schema bundled. It can be used by the IDE
   to get typesafe, autocompletion and documentation. It is generated from the files
   in [json-schema](src/main/json-schema) by the Gradle task `./gradlew bundleJsonSchema`.


### PR DESCRIPTION
This change ensures that the version of the JSON Schema CLI used by a developer's machine is the same as that used by the CI pipeline. Also, developers do not need to install the JSON schema CLI manually on their machines.